### PR TITLE
Leverage MinServerVersion in plugin.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/scottleedavis/mattermost-plugin-remind
 go 1.12
 
 require (
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-ldap/ldap v3.0.3+incompatible // indirect
 	github.com/gorilla/mux v1.7.2
 	github.com/mattermost/mattermost-server v5.12.0+incompatible

--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,7 @@
     "name": "Remind Bot",
     "description": "Sets Reminders for users and channels",
     "version": "0.4.1",
+    "min_server_version": "5.12.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/activate.go
+++ b/server/activate.go
@@ -2,36 +2,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/blang/semver"
-	"github.com/mattermost/mattermost-server/model"
-	"github.com/pkg/errors"
 	"path/filepath"
 	"time"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/pkg/errors"
 )
 
-const minimumServerVersion = "5.12.0"
 const botName = "remindbot"
 const botDisplayName = "Remindbot"
 
-func (p *Plugin) checkServerVersion() error {
-	serverVersion, err := semver.Parse(p.API.GetServerVersion())
-	if err != nil {
-		return errors.Wrap(err, "failed to parse server version")
-	}
-
-	r := semver.MustParseRange(">=" + minimumServerVersion)
-	if !r(serverVersion) {
-		return fmt.Errorf("this plugin requires Mattermost v%s or later", minimumServerVersion)
-	}
-
-	return nil
-}
-
 func (p *Plugin) OnActivate() error {
-	if err := p.checkServerVersion(); err != nil {
-		return err
-	}
-
 	p.ServerConfig = p.API.GetConfig()
 	if p.ServerConfig.ServiceSettings.SiteURL == nil {
 		return errors.New("siteURL is not set. Please set a siteURL and restart the plugin")


### PR DESCRIPTION
This takes advantage of built-in version constraint checking within [Mattermost v5.6+](https://github.com/mattermost/mattermost-server/pull/9743). I realize this won't actually enforce the version check prior to v5.6+, but thought I'd submit in case it that was acceptable.