### PR TITLE
Make an i18n test more robust

### DIFF
--- a/server/i18n_test.go
+++ b/server/i18n_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 	"github.com/stretchr/testify/mock"
@@ -49,9 +50,7 @@ func TestTranslationsPreInit(t *testing.T) {
 		p := &Plugin{}
 		p.API = api
 		err = p.TranslationsPreInit()
-		require.True(t, err.Error() == "unable to read i18n directory: readdirent: invalid argument" ||
-			err.Error() == "unable to read i18n directory: readdirent: not a directory" ||
-			err.Error() == "unable to read i18n directory: fdopendir: not a directory")
+		require.True(t, strings.Contains(err.Error(), "unable to read i18n directory"))
 
 	})
 


### PR DESCRIPTION
I'm trying to do a bit of maintenance on mattermost-plugin-remind (fixing some issues, maybe upgrade the plugin to Mattermost v6). This is a first small PR to test the waters :)

There's an i18n test that currently breaks on macOS 11, because the error message is formatted slightly differently. This PR makes the test more tolerant to different formatting.

/cc @hanzei @scottleedavis 