### PR TITLE
Refactor and test the reminders list

### DIFF
--- a/server/list.go
+++ b/server/list.go
@@ -144,23 +144,28 @@ func (p *Plugin) categorizeOccurrences(reminders []Reminder) (
 			t := occurrence.Occurrence
 			s := occurrence.Snoozed
 
-			if !strings.HasPrefix(reminder.Target, "~") &&
-				reminder.Completed == p.emptyTime &&
-				((occurrence.Repeat == "" && t.After(time.Now().UTC())) ||
+			isChannelReminder := strings.HasPrefix(reminder.Target, "~")
+			isCompleted := reminder.Completed != p.emptyTime
+			isPast := t.Before(time.Now().UTC())
+			isFuture := t.After(time.Now().UTC())
+
+			if !isChannelReminder &&
+				!isCompleted &&
+				((occurrence.Repeat == "" && isFuture) ||
 					(s != p.emptyTime && s.After(time.Now().UTC()))) {
 				upcomingOccurrences = append(upcomingOccurrences, occurrence)
-			} else if !strings.HasPrefix(reminder.Target, "~") &&
-				occurrence.Repeat != "" && t.After(time.Now().UTC()) {
+			} else if !isChannelReminder &&
+				occurrence.Repeat != "" && isFuture {
 				recurringOccurrences = append(recurringOccurrences, occurrence)
-			} else if reminder.Completed == p.emptyTime &&
-				t.Before(time.Now().UTC()) &&
+			} else if !isCompleted &&
+				isPast &&
 				(s == p.emptyTime || s.Before(time.Now().UTC())) {
 				pastOccurrences = append(pastOccurrences, occurrence)
-			} else if strings.HasPrefix(reminder.Target, "~") &&
-				reminder.Completed == p.emptyTime &&
-				t.After(time.Now().UTC()) {
+			} else if isChannelReminder &&
+				!isCompleted &&
+				isFuture {
 				channelOccurrences = append(channelOccurrences, occurrence)
-			} else if reminder.Completed != p.emptyTime {
+			} else if isCompleted {
 				//p.API.LogInfo("completed reminder: " + fmt.Sprintf("%v", reminder))
 			} else {
 				//p.API.LogInfo("unknown reminder: " + fmt.Sprintf("%v", reminder))

--- a/server/list_test.go
+++ b/server/list_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListReminders(t *testing.T) {
+	p := &Plugin{}
 
 	user := &model.User{
 		Email:    "-@-.-",
@@ -22,53 +23,109 @@ func TestListReminders(t *testing.T) {
 		Locale:   "en",
 	}
 
-	occurrences := []Occurrence{
-		{
-			Id:         model.NewId(),
-			ReminderId: model.NewId(),
-			Occurrence: time.Now(),
-		},
-	}
-
-	reminders := []Reminder{
-		{
-			Id:          model.NewId(),
-			Username:    user.Username,
-			Message:     "Message",
-			When:        "in 1 second",
-			Occurrences: occurrences,
-			Completed:   time.Time{}.AddDate(1, 1, 1),
-		},
-	}
-
-	stringReminders, _ := json.Marshal(reminders)
-
-	channel := &model.Channel{
+	originChannel := &model.Channel{
 		Id: model.NewId(),
 	}
 
-	setupAPI := func() *plugintest.API {
+	publicChannel := &model.Channel{
+		Id: model.NewId(),
+		Name: "public-channel",
+	}
+
+	T, _ := p.translation(user)
+
+	pastOccurrenceDate := time.Now().Add(-1*time.Minute)
+	futureOccurrenceDate := time.Now().Add(1*time.Minute)
+
+	pastReminder := Reminder{
+		Id:          model.NewId(),
+		Username:    user.Username,
+		Message:     "This reminder was triggered a single time",
+		When:        "in 1 minute",
+		Occurrences: []Occurrence{
+			{
+				Id:         model.NewId(),
+				ReminderId: model.NewId(),
+				Occurrence: pastOccurrenceDate,
+			},
+		},
+		Completed: p.emptyTime,
+	}
+
+	upcomingReminder := Reminder{
+		Id:          model.NewId(),
+		Username:    user.Username,
+		Message:     "This reminder triggers a single time",
+		When:        "in 1 minute",
+		Occurrences: []Occurrence{
+			{
+				Id:         model.NewId(),
+				ReminderId: model.NewId(),
+				Occurrence: futureOccurrenceDate,
+			},
+		},
+		Completed: p.emptyTime,
+	}
+
+	channelReminder := Reminder{
+		Id:          model.NewId(),
+		Username:    user.Username,
+		Target:      "~" + publicChannel.Name,
+		Message:     "This reminder posts in a channel a single time",
+		When:        "in 1 minute",
+		Occurrences: []Occurrence{
+			{
+				Id:         model.NewId(),
+				ReminderId: model.NewId(),
+				Occurrence: futureOccurrenceDate,
+			},
+		},
+		Completed: p.emptyTime,
+	}
+
+	recurringReminder := Reminder{
+		Id:          model.NewId(),
+		Username:    user.Username,
+		Message:     "This reminder triggers several times",
+		When:        "every Monday",
+		Occurrences: []Occurrence{
+			{
+				Id:         model.NewId(),
+				ReminderId: model.NewId(),
+				Repeat:     "every Monday at 9:00AM",
+				Occurrence: futureOccurrenceDate,
+			},
+		},
+		Completed: p.emptyTime,
+	}
+
+	setupAPI := func(reminders []Reminder) *plugintest.API {
+		serializedReminders, _ := json.Marshal(reminders)
 		api := &plugintest.API{}
 		api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything).Maybe()
 		api.On("LogError", mock.Anything, mock.Anything, mock.Anything).Maybe()
 		api.On("LogInfo", mock.Anything).Maybe()
 		api.On("GetUserByUsername", mock.AnythingOfType("string")).Return(user, nil)
-		api.On("KVGet", mock.Anything).Return(stringReminders, nil)
+		api.On("KVGet", "testuser").Return(serializedReminders, nil)
 		return api
 	}
 
-	t.Run("if list happens", func(t *testing.T) {
+	t.Run("the list categorizes reminders by type", func(t *testing.T) {
+		reminders := []Reminder { pastReminder, upcomingReminder, channelReminder, recurringReminder }
+		p.API = setupAPI(reminders)
 
-		api := setupAPI()
-		defer api.AssertExpectations(t)
+		post := p.ListReminders(user, originChannel.Id)
 
-		p := &Plugin{}
-		p.API = api
-
-		assert.NotNil(t, p.ListReminders(user, channel.Id))
-
+		attachments := post.Attachments()
+		assert.NotNil(t, post, "A post must be returned")
+		assert.Equal(t, post.ChannelId, originChannel.Id, "The list must be posted to the channel it was requested")
+		assert.Equal(t, len(reminders) + 1, len(attachments), "The list must have one attachment per active reminder, plus an attachment for control")
+		assert.Contains(t, attachments[0].Text, T("list.upcoming"), "The first displayed reminders must be upcoming reminders")
+		assert.Contains(t, attachments[1].Text, T("list.recurring"), "The next displayed reminders must be recurring reminders")
+		assert.Contains(t, attachments[2].Text, T("list.past.and.incomplete"), "The next displayed reminders must be past and incomplete reminders")
+		assert.Contains(t, attachments[3].Text, T("list.channel"), "The next displayed reminders must be channel reminders")
+		assert.Contains(t, attachments[len(attachments)-1].Text, T("reminders.page.numbers"), "The last attachment must be list pagination and controls")
 	})
-
 }
 
 func TestUpdateListReminders(t *testing.T) {


### PR DESCRIPTION
This PR is a preparation for fixing #214.

It refactors some elements of the reminders list:
- renaming some variables in the implementation, to make the behavior easier to understand;
- adding extensive tests.

There's no behavior change for now (it will come in a following PR).

/cc @hanzei @scottleedavis