### PR TITLE
fix: post channel reminders as custom message type

### DIFF
--- a/server/reminder.go
+++ b/server/reminder.go
@@ -281,6 +281,7 @@ func (p *Plugin) TriggerReminders() {
 						ChannelId:     channel.Id,
 						PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
 						UserId:        p.remindUserId,
+						Type:          model.POST_CUSTOM_TYPE_PREFIX + "reminder",
 						Message:       T("reminder.message", messageParameters),
 						Props:         model.StringInterface{},
 					}


### PR DESCRIPTION
This fixes the "@channel" and "@here" keywords not triggering mentions.

By default, bot users are not allowed to trigger channel mentions. However, if the message type is not the default, this check is bypassed.

This was discussed with the mattermost-server folks, and it seems an approved workaround for this issue.

Fix #204